### PR TITLE
change database schema

### DIFF
--- a/appinfo/application.php
+++ b/appinfo/application.php
@@ -19,6 +19,7 @@ use OCP\IContainer;
 
 use OCA\B2shareBridge\Controller\B2shareBridge;
 use OCA\B2shareBridge\Db\FilecacheStatusMapper;
+use OCA\B2shareBridge\Db\StatusCodeMapper;
 use OCA\B2shareBridge\Publish;
 
 /**
@@ -58,6 +59,16 @@ class Application extends App
                 );
             }
         );
+        
+        $container->registerService(
+            'StatusCodeMapper',
+            function (IContainer $c) {
+                $server = $c->query('ServerContainer');
+                return new StatusCodeMapper(
+                    $server->getDatabaseConnection()
+                );
+            }
+        );
 
         $container->registerService(
             'B2shareBridgeController',
@@ -68,6 +79,7 @@ class Application extends App
                     $server->getRequest(),
                     $server->getConfig(),
                     $c->query('FilecacheStatusMapper'),
+                    $c->query('StatusCodeMapper'),
                     $c->query('CurrentUID')
                 );
             }

--- a/appinfo/database.xml
+++ b/appinfo/database.xml
@@ -30,9 +30,9 @@
             </field>
             <field>
                 <name>status</name>
-                <type>text</type>
+                <type>integer</type>
                 <notnull>true</notnull>
-                <length>128</length>
+                <length>4</length>
             </field>
             <field>
                 <name>created_at</name>

--- a/appinfo/database.xml
+++ b/appinfo/database.xml
@@ -59,6 +59,7 @@
                 <default>0</default>
                 <notnull>true</notnull>
                 <length>4</length>
+                <autoincrement>1</autoincrement>
             </field>
             <field>
                 <name>message</name>

--- a/appinfo/database.xml
+++ b/appinfo/database.xml
@@ -50,4 +50,22 @@
             </field>
         </declaration>
     </table>
+    <table>
+        <name>*dbprefix*b2sharebridge_status_code</name>
+        <declaration>
+            <field>
+                <name>status_code</name>
+                <type>integer</type>
+                <default>0</default>
+                <notnull>true</notnull>
+                <length>4</length>
+            </field>
+            <field>
+                <name>message</name>
+                <type>text</type>
+                <default></default>
+                <notnull>true</notnull>
+            </field>
+        </declaration>
+    </table>
 </database>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -10,7 +10,7 @@
     </description>
     <licence>AGPL</licence>
     <author>EUDAT</author>
-    <version>0.0.8</version>
+    <version>0.0.7</version>
     <dependencies>
         <owncloud min-version="8.1" max-version="9.1" />
     </dependencies>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -10,7 +10,7 @@
     </description>
     <licence>AGPL</licence>
     <author>EUDAT</author>
-    <version>0.0.6</version>
+    <version>0.0.8</version>
     <dependencies>
         <owncloud min-version="8.1" max-version="9.1" />
     </dependencies>

--- a/lib/controller/b2sharebridge.php
+++ b/lib/controller/b2sharebridge.php
@@ -40,6 +40,7 @@ use OCA\B2shareBridge\Db\StatusCodeMapper;
 class B2shareBridge extends Controller
 {
     private $_userId;
+    private $_statusCodes;
 
     /**
      * Creates the AppFramwork Controller
@@ -65,6 +66,7 @@ class B2shareBridge extends Controller
         $this->scMapper = $scMapper;
         $this->config = $config;
         $this->_initStatusCode();
+        $this->_statusCodes = $this->_listStatusCodes();
 
     }
 
@@ -372,5 +374,28 @@ class B2shareBridge extends Controller
             ];
             $this->scMapper->insertStatusCode($statuscode->fromParams($params));
         }
+    }
+    
+    /**
+     * CAUTION: the @Stuff turns off security checks; for this page no admin is
+     *          required and no CSRF check. If you don't know what CSRF is, read
+     *          it up in the docs or you might create a security hole. This is
+     *          basically the only required method to add this exemption, don't
+     *          add it to any other method if you don't exactly know what it does
+     *
+     * @return array
+     * 
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    private function _listStatusCodes()
+    {
+        $statuscodes = [];
+        foreach (
+                $this->scMapper->findAllStatusCodes()
+            as $statuscode) {
+                $statuscodes[] = $statuscode->getMessage();
+        }
+        return $statuscodes;
     }
 }

--- a/lib/controller/b2sharebridge.php
+++ b/lib/controller/b2sharebridge.php
@@ -26,6 +26,7 @@ use OCA\B2shareBridge\Job\TransferHandler;
 use OCA\B2shareBridge\Db\FilecacheStatusMapper;
 use OCA\B2shareBridge\Db\FilecacheStatus;
 use OCA\B2shareBridge\Db\StatusCode;
+use OCA\B2shareBridge\Db\StatusCodeMapper;
 
 /**
  * Implement a ownCloud AppFramework Controller
@@ -43,23 +44,27 @@ class B2shareBridge extends Controller
     /**
      * Creates the AppFramwork Controller
      *
-     * @param string                $appName name of the app
-     * @param IRequest              $request request object
-     * @param IConfig               $config  config object
-     * @param FilecacheStatusMapper $mapper  whatever
-     * @param string                $userId  userid
+     * @param string                $appName  name of the app
+     * @param IRequest              $request  request object
+     * @param IConfig               $config   config object
+     * @param FilecacheStatusMapper $mapper   whatever
+     * @param StatusCodeMapper      $scMapper whatever
+     * @param string                $userId   userid
      */
     public function __construct(
         $appName,
         IRequest $request,
         IConfig $config,
         FilecacheStatusMapper $mapper,
+        StatusCodeMapper $scMapper,
         $userId
     ) {
         parent::__construct($appName, $request);
         $this->_userId = $userId;
         $this->mapper = $mapper;
+        $this->scMapper = $scMapper;
         $this->config = $config;
+        $this->initStatusCode();
 
     }
 
@@ -318,5 +323,29 @@ class B2shareBridge extends Controller
                 'status' => 'success'
             ]
         );
+    }
+    
+    /**
+     * CAUTION: the @Stuff turns off security checks; for this page no admin is
+     *          required and no CSRF check. If you don't know what CSRF is, read
+     *          it up in the docs or you might create a security hole. This is
+     *          basically the only required method to add this exemption, don't
+     *          add it to any other method if you don't exactly know what it does
+     *
+     * @return something
+     * 
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function initStatusCode()
+    {
+        if ($this->scMapper->findCountForStatusCodes() != 1) {
+            $params = [
+                'statusCode' => 0,
+                'message' => 'dummy'
+            ];
+            $statuscode = new StatusCode();
+            $this->scMapper->insertStatusCode($statuscode->fromParams($params));
+        }
     }
 }

--- a/lib/controller/b2sharebridge.php
+++ b/lib/controller/b2sharebridge.php
@@ -64,7 +64,7 @@ class B2shareBridge extends Controller
         $this->mapper = $mapper;
         $this->scMapper = $scMapper;
         $this->config = $config;
-        $this->initStatusCode();
+        $this->_initStatusCode();
 
     }
 
@@ -337,14 +337,39 @@ class B2shareBridge extends Controller
      * @NoAdminRequired
      * @NoCSRFRequired
      */
-    public function initStatusCode()
+    private function _initStatusCode()
     {
-        if ($this->scMapper->findCountForStatusCodes() != 1) {
+        if ($this->scMapper->findCountForStatusCodes() != 6) {
+            $statuscode = new StatusCode();
             $params = [
                 'statusCode' => 0,
-                'message' => 'dummy'
+                'message' => 'published'
             ];
-            $statuscode = new StatusCode();
+            $this->scMapper->insertStatusCode($statuscode->fromParams($params));
+            $params = [
+                'statusCode' => 1,
+                'message' => 'new'
+            ];
+            $this->scMapper->insertStatusCode($statuscode->fromParams($params));
+            $params = [
+                'statusCode' => 2,
+                'message' => 'processing'
+            ];
+            $this->scMapper->insertStatusCode($statuscode->fromParams($params));
+            $params = [
+                'statusCode' => 3,
+                'message' => 'External error: during uploading file'
+            ];
+            $this->scMapper->insertStatusCode($statuscode->fromParams($params));
+            $params = [
+                'statusCode' => 4,
+                'message' => 'External error: during creating deposit'
+            ];
+            $this->scMapper->insertStatusCode($statuscode->fromParams($params));
+            $params = [
+                'statusCode' => 5,
+                'message' => 'Internal error: file not accessible'
+            ];
             $this->scMapper->insertStatusCode($statuscode->fromParams($params));
         }
     }

--- a/lib/controller/b2sharebridge.php
+++ b/lib/controller/b2sharebridge.php
@@ -41,7 +41,7 @@ class B2shareBridge extends Controller
 {
     private $_userId;
     private $_statusCodes;
-    private $_lastGoodStatusCode = 2;
+    private $_lastGoodStatusCode;
 
     /**
      * Creates the AppFramwork Controller
@@ -68,7 +68,7 @@ class B2shareBridge extends Controller
         $this->config = $config;
         $this->_initStatusCode();
         $this->_statusCodes = $this->_listStatusCodes();
-
+        $this->_lastGoodStatusCode = array_search('processing', $this->_statusCodes);
     }
 
     /**
@@ -281,7 +281,9 @@ class B2shareBridge extends Controller
             5
         );
 
-        $active_uploads = $this->mapper->findCountForUser($_userId);
+        $active_uploads = $this->mapper->findCountForUser(
+            $_userId, array_search('new', $this->_statusCodes)
+        );
         if ($active_uploads < $allowed_uploads) {
 
             Filesystem::init($_userId, '/');

--- a/lib/controller/b2sharebridge.php
+++ b/lib/controller/b2sharebridge.php
@@ -41,6 +41,7 @@ class B2shareBridge extends Controller
 {
     private $_userId;
     private $_statusCodes;
+    private $_lastGoodStatusCode = 2;
 
     /**
      * Creates the AppFramwork Controller
@@ -104,7 +105,9 @@ class B2shareBridge extends Controller
         $publications = [];
         foreach (
             array_reverse(
-                $this->mapper->findSuccessfulForUser($this->_userId)
+                $this->mapper->findSuccessfulForUser(
+                    $this->_userId, $this->_lastGoodStatusCode
+                )
             ) as $publication) {
                 $publications[] = $publication;
         }
@@ -112,7 +115,9 @@ class B2shareBridge extends Controller
         $fails = [];
         foreach (
             array_reverse(
-                $this->mapper->findFailedForUser($this->_userId)
+                $this->mapper->findFailedForUser(
+                    $this->_userId, $this->_lastGoodStatusCode
+                )
             ) as $fail) {
                 $fails[] = $fail;
         }
@@ -181,7 +186,9 @@ class B2shareBridge extends Controller
         $publications = [];
         foreach (
             array_reverse(
-                $this->mapper->findSuccessfulForUser($this->_userId)
+                $this->mapper->findSuccessfulForUser(
+                    $this->_userId, $this->_lastGoodStatusCode
+                )
             ) as $publication) {
                 $publications[] = $publication;
         }
@@ -210,7 +217,9 @@ class B2shareBridge extends Controller
         $fails = [];
         foreach (
             array_reverse(
-                $this->mapper->findFailedForUser($this->_userId)
+                $this->mapper->findFailedForUser(
+                    $this->_userId, $this->_lastGoodStatusCode
+                )
             ) as $fail) {
                 $fails[] = $fail;
         }

--- a/lib/controller/b2sharebridge.php
+++ b/lib/controller/b2sharebridge.php
@@ -121,7 +121,8 @@ class B2shareBridge extends Controller
             'user' => $this->_userId,
             'transfers' => $cron_transfers,
             'publications' => $publications,
-            'fails' => $fails
+            'fails' => $fails,
+            'statuscodes' => $this->_statusCodes
         ];
         return new TemplateResponse('b2sharebridge', 'main', $params);
     }
@@ -187,7 +188,8 @@ class B2shareBridge extends Controller
 
         $params = [
             'user' => $this->_userId,
-            'publications' => $publications
+            'publications' => $publications,
+            'statuscodes' => $this->_statusCodes
         ];
         return new TemplateResponse('b2sharebridge', 'published', $params);
     }
@@ -215,7 +217,8 @@ class B2shareBridge extends Controller
 
         $params = [
             'user' => $this->_userId,
-            'fails' => $fails
+            'fails' => $fails,
+            'statuscodes' => $this->_statusCodes
         ];
         return new TemplateResponse('b2sharebridge', 'failed', $params);
     }

--- a/lib/controller/b2sharebridge.php
+++ b/lib/controller/b2sharebridge.php
@@ -25,6 +25,7 @@ use OCP\Util;
 use OCA\B2shareBridge\Job\TransferHandler;
 use OCA\B2shareBridge\Db\FilecacheStatusMapper;
 use OCA\B2shareBridge\Db\FilecacheStatus;
+use OCA\B2shareBridge\Db\StatusCode;
 
 /**
  * Implement a ownCloud AppFramework Controller

--- a/lib/controller/b2sharebridge.php
+++ b/lib/controller/b2sharebridge.php
@@ -283,7 +283,7 @@ class B2shareBridge extends Controller
                 $fcStatus = new FilecacheStatus();
                 $fcStatus->setFileid($id);
                 $fcStatus->setOwner($_userId);
-                $fcStatus->setStatus("new");
+                $fcStatus->setStatus(1);//status = new
                 $fcStatus->setCreatedAt(time());
                 $fcStatus->setUpdatedAt(time());
                 $this->mapper->insert($fcStatus);

--- a/lib/db/filecachestatusmapper.php
+++ b/lib/db/filecachestatusmapper.php
@@ -120,34 +120,36 @@ class FilecacheStatusMapper extends Mapper
     /**
      * Return all failed file transfers for current user
      *
-     * @param string $user name of the user to search transfers for
+     * @param string  $user               name of the user to search transfers for
+     * @param integer $lastGoodStatusCode last status code for a sucessful transfer
      *
      * @throws \OCP\AppFramework\Db\DoesNotExistException if not found
      * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException if more th one
      *
      * @return array(Entities)
      */
-    public function findFailedForUser($user)
+    public function findFailedForUser($user, $lastGoodStatusCode)
     {
         $sql = 'SELECT * FROM `*PREFIX*b2sharebridge_filecache_status` '
             . 'WHERE `status` > ? AND `owner` = ?';
-        return $this->findEntities($sql, [2, $user]);
+        return $this->findEntities($sql, [$lastGoodStatusCode, $user]);
     }
     
     /**
      * Return all failed file transfers for current user
      *
-     * @param string $user name of the user to search transfers for
+     * @param string  $user               name of the user to search transfers for
+     * @param integer $lastGoodStatusCode last status code for a sucessful transfer
      *
      * @throws \OCP\AppFramework\Db\DoesNotExistException if not found
      * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException if more th one
      *
      * @return array(Entities)
      */
-    public function findSuccessfulForUser($user)
+    public function findSuccessfulForUser($user, $lastGoodStatusCode)
     {
         $sql = 'SELECT * FROM `*PREFIX*b2sharebridge_filecache_status` '
-            . 'WHERE `status` < ? AND `owner` = ?';
-        return $this->findEntities($sql, [3, $user]);
+            . 'WHERE `status` <= ? AND `owner` = ?';
+        return $this->findEntities($sql, [$lastGoodStatusCode, $user]);
     }
 }

--- a/lib/db/filecachestatusmapper.php
+++ b/lib/db/filecachestatusmapper.php
@@ -103,18 +103,19 @@ class FilecacheStatusMapper extends Mapper
     /**
      * Return the number of currently queued file transfers for a given user
      *
-     * @param string $user name of the user to search transfers for
+     * @param string  $user       name of the user to search transfers for
+     * @param integer $statuscode statuscode to search transfers for
      *
      * @throws \OCP\AppFramework\Db\DoesNotExistException if not found
      * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException if more th one
      *
      * @return int number of active publishs per user
      */
-    public function findCountForUser($user)
+    public function findCountForUser($user, $statuscode)
     {
         $sql = 'SELECT COUNT(*) FROM `*PREFIX*b2sharebridge_filecache_status` '
             .'WHERE owner = ? AND status = ?';
-        return $this->execute($sql, [$user, 'new'])->fetchColumn();
+        return $this->execute($sql, [$user, $statuscode])->fetchColumn();
     }
 
     /**

--- a/lib/db/filecachestatusmapper.php
+++ b/lib/db/filecachestatusmapper.php
@@ -130,8 +130,8 @@ class FilecacheStatusMapper extends Mapper
     public function findFailedForUser($user)
     {
         $sql = 'SELECT * FROM `*PREFIX*b2sharebridge_filecache_status` '
-            . 'WHERE `status` = ? AND `owner` = ?';
-        return $this->findEntities($sql, ['error', $user]);
+            . 'WHERE `status` > ? AND `owner` = ?';
+        return $this->findEntities($sql, [2, $user]);
     }
     
     /**
@@ -147,7 +147,7 @@ class FilecacheStatusMapper extends Mapper
     public function findSuccessfulForUser($user)
     {
         $sql = 'SELECT * FROM `*PREFIX*b2sharebridge_filecache_status` '
-            . 'WHERE `status` != ? AND `owner` = ?';
-        return $this->findEntities($sql, ['error', $user]);
+            . 'WHERE `status` < ? AND `owner` = ?';
+        return $this->findEntities($sql, [3, $user]);
     }
 }

--- a/lib/db/migration.sql
+++ b/lib/db/migration.sql
@@ -1,0 +1,6 @@
+UPDATE oc_b2sharebridge_filecache_status SET status=0 WHERE status='published';
+UPDATE oc_b2sharebridge_filecache_status SET status=1 WHERE status='new';
+UPDATE oc_b2sharebridge_filecache_status SET status=2 WHERE status='processing';
+UPDATE oc_b2sharebridge_filecache_status SET status=3 WHERE status='External error: during uploading file';
+UPDATE oc_b2sharebridge_filecache_status SET status=4 WHERE status='External error: during creating deposit';
+UPDATE oc_b2sharebridge_filecache_status SET status=5 WHERE status='Internal error: file not accessible';

--- a/lib/db/statuscode.php
+++ b/lib/db/statuscode.php
@@ -39,5 +39,15 @@ class StatusCode extends Entity
         $this->addType('statusCode', 'integer');
         $this->addType('message', 'string');
     }
+    
+    /**
+     * Get message for statusCode
+     *
+     * @return \string
+     */
+    public function getMessage()
+    {
+        return $this->message;
+    }
 
 }

--- a/lib/db/statuscode.php
+++ b/lib/db/statuscode.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * OwnCloud - B2sharebridge App
+ *
+ * PHP Version 5-7
+ *
+ * @category  Owncloud
+ * @package   B2shareBridge
+ * @author    EUDAT <b2drop-devel@postit.csc.fi>
+ * @copyright 2015 EUDAT
+ * @license   AGPL3 https://github.com/EUDAT-B2DROP/b2sharebridge/blob/master/LICENSE
+ * @link      https://github.com/EUDAT-B2DROP/b2sharebridge.git
+ */
+
+namespace OCA\B2shareBridge\Db;
+
+use OC\Files\Filesystem;
+use OCP\AppFramework\Db\Entity;
+
+/**
+ * Creates a database entity for the status code of fileuploads
+ *
+ * @category Owncloud
+ * @package  B2shareBridge
+ * @author   EUDAT <b2drop-devel@postit.csc.fi>
+ * @license  AGPL3 https://github.com/EUDAT-B2DROP/b2sharebridge/blob/master/LICENSE
+ * @link     https://github.com/EUDAT-B2DROP/b2sharebridge.git
+ */
+class StatusCode extends Entity
+{
+    protected $statusCode;
+    protected $message;
+
+    /**
+     * Creates the actual database entity
+     */
+    public function __construct()
+    {
+        $this->addType('statusCode', 'integer');
+        $this->addType('message', 'string');
+    }
+
+}

--- a/lib/db/statuscodemapper.php
+++ b/lib/db/statuscodemapper.php
@@ -71,7 +71,7 @@ class StatusCodeMapper extends Mapper
      */
     public function findCountForStatusCodes()
     {
-        $sql = 'SELECT COUNT(*) FROM `*PREFIX*b2sharebridge_status_codes`'
+        $sql = 'SELECT COUNT(*) FROM `*PREFIX*b2sharebridge_status_code`';
         return $this->execute($sql)->fetchColumn();
     }
     

--- a/lib/db/statuscodemapper.php
+++ b/lib/db/statuscodemapper.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * OwnCloud - B2sharebridge App
+ *
+ * PHP Version 5-7
+ *
+ * @category  Owncloud
+ * @package   B2shareBridge
+ * @author    EUDAT <b2drop-devel@postit.csc.fi>
+ * @copyright 2015 EUDAT
+ * @license   AGPL3 https://github.com/EUDAT-B2DROP/b2sharebridge/blob/master/LICENSE
+ * @link      https://github.com/EUDAT-B2DROP/b2sharebridge.git
+ */
+
+namespace OCA\B2shareBridge\Db;
+
+use OCP\AppFramework\Db\Entity;
+use OCP\IDBConnection;
+use OCP\AppFramework\Db\Mapper;
+
+/**
+ * Work on a database table
+ *
+ * @category Owncloud
+ * @package  B2shareBridge
+ * @author   EUDAT <b2drop-devel@postit.csc.fi>
+ * @license  AGPL3 https://github.com/EUDAT-B2DROP/b2sharebridge/blob/master/LICENSE
+ * @link     https://github.com/EUDAT-B2DROP/b2sharebridge.git
+ */
+class StatusCodeMapper extends Mapper
+{
+
+    /**
+     * Create the database mapper
+     *
+     * @param IDBConnection $db the database connection to use
+     */
+    public function __construct(IDBConnection $db)
+    {
+        parent::__construct(
+            $db,
+            'b2sharebridge_status_code',
+            '\OCA\B2shareBridge\Db\StatusCode'
+        );
+    }
+
+    /**
+     * Find a database entry for a status code
+     *
+     * @param string $status_code statusCode to find a transfer entry for
+     *
+     * @throws \OCP\AppFramework\Db\DoesNotExistException if not found
+     * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException if more th one
+     *
+     * @return Entity
+     */
+    public function find($status_code)
+    {
+        $sql = 'SELECT * FROM `*PREFIX*b2sharebridge_status_code` '
+            . 'WHERE `status_code` = ?';
+        return $this->findEntity($sql, [$status_code]);
+    }
+
+}

--- a/lib/db/statuscodemapper.php
+++ b/lib/db/statuscodemapper.php
@@ -60,5 +60,34 @@ class StatusCodeMapper extends Mapper
             . 'WHERE `status_code` = ?';
         return $this->findEntity($sql, [$status_code]);
     }
+    
+     /**
+     * Return the number of currently lsited status codes
+     *
+     * @throws \OCP\AppFramework\Db\DoesNotExistException if not found
+     * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException if more th one
+     *
+     * @return int number of status codes
+     */
+    public function findCountForStatusCodes()
+    {
+        $sql = 'SELECT COUNT(*) FROM `*PREFIX*b2sharebridge_status_codes`'
+        return $this->execute($sql)->fetchColumn();
+    }
+    
+     /**
+     * Insert a new status code with message
+     *
+     * @param entity $code contains statusCode and message
+     *
+     * @throws \OCP\AppFramework\Db\DoesNotExistException if not found
+     * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException if more th one
+     *
+     * @return int number of active publishs per user
+     */
+    public function insertStatusCode($code)
+    {
+        $this->insert($code);
+    }
 
 }

--- a/lib/db/statuscodemapper.php
+++ b/lib/db/statuscodemapper.php
@@ -61,6 +61,20 @@ class StatusCodeMapper extends Mapper
         return $this->findEntity($sql, [$status_code]);
     }
     
+    /**
+     * Find all database entry for status codes
+     *
+     * @throws \OCP\AppFramework\Db\DoesNotExistException if not found
+     * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException if more th one
+     *
+     * @return Entity
+     */
+    public function findAllStatusCodes()
+    {
+        $sql = 'SELECT * FROM `*PREFIX*b2sharebridge_status_code`';
+        return $this->findEntities($sql);
+    }
+    
      /**
      * Return the number of currently lsited status codes
      *

--- a/lib/job/transferhandler.php
+++ b/lib/job/transferhandler.php
@@ -93,7 +93,7 @@ class TransferHandler extends QueuedJob
         // get the file transfer object for current job
         $fcStatus = $this->_mapper->find($args['transferId']);
 
-        $fcStatus->setStatus("processing");
+        $fcStatus->setStatus(2);//status = processing
         $this->_mapper->update($fcStatus);
         $user = $fcStatus->getOwner();
         $fileId = $fcStatus->getFileid();
@@ -115,19 +115,19 @@ class TransferHandler extends QueuedJob
                 $upload_result = $this->_publisher->upload($handle, $size);
 
                 if ($upload_result) {
-                    $fcStatus->setStatus('published');
+                    $fcStatus->setStatus(0);//status = published
                     $fcStatus->setUrl($create_result);
                 } else {
                     /**External error: during uploading file*/
-                    $fcStatus->setStatus('error');
+                    $fcStatus->setStatus(3);
                 }
             } else {
                 /**External error: during creating deposit*/
-                $fcStatus->setStatus('error');
+                $fcStatus->setStatus(4);
             }
         } else {
             /**Internal error: file not accessible*/
-            $fcStatus->setStatus('error');
+            $fcStatus->setStatus(5);
         }
         $fcStatus->setUpdatedAt(time());
         $this->_mapper->update($fcStatus);
@@ -194,7 +194,7 @@ class TransferHandler extends QueuedJob
         // TODO: make sure the user can access the file
         $fcStatus = $this->_mapper->find($args['transferId']);
 
-        $fcStatus->setStatus("processing");
+        $fcStatus->setStatus(2);//status = processing
         $this->_mapper->update($fcStatus);
         Util::writeLog('transfer', 'FORKED2', 3);
 

--- a/templates/failed.php
+++ b/templates/failed.php
@@ -31,7 +31,7 @@ style('files', 'files');
                                 <td><?php p($fail->getId()) ?></td>
                                 <td><?php p($fail->getFilename()) ?></td>
                                 <?php // TODO: echo as user specific timedate ?>
-                                <td><?php p($fail->getStatus()) ?></td>
+                                <td><?php p($_['statuscodes'][$fail->getStatus()]) ?></td>
                                 <td><a target="_blank" href=<?php p($fail->getUrl()) ?>>URL</a></td>
                                 <td><?php p(date('D\, j M Y H:i:s', $fail->getCreatedAt())) ?></td>
                                 <td><?php p(date('D\, j M Y H:i:s', $fail->getUpdatedAt())) ?></td>

--- a/templates/main.php
+++ b/templates/main.php
@@ -60,7 +60,7 @@ style('files', 'files');
                                 <td><?php p($publication->getId()) ?></td>
                                 <td><?php p($publication->getFilename()) ?></td>
                                 <?php // TODO: echo as user specific timedate ?>
-                                <td><?php p($publication->getStatus()) ?></td>
+                                <td><?php p($_['statuscodes'][$publication->getStatus()]) ?></td>
                                 <td><a target="_blank" href=<?php p($publication->getUrl()) ?>>URL</a></td>
                                 <td><?php p(date('D\, j M Y H:i:s', $publication->getCreatedAt())) ?></td>
                                 <td><?php p(date('D\, j M Y H:i:s', $publication->getUpdatedAt())) ?></td>
@@ -95,7 +95,7 @@ style('files', 'files');
                                 <td><?php p($fail->getId()) ?></td>
                                 <td><?php p($fail->getFilename()) ?></td>
                                 <?php // TODO: echo as user specific timedate ?>
-                                <td><?php p($fail->getStatus()) ?></td>
+                                <td><?php p($_['statuscodes'][$fail->getStatus()]) ?></td>
                                 <td><a target="_blank" href=<?php p($fail->getUrl()) ?>>URL</a></td>
                                 <td><?php p(date('D\, j M Y H:i:s', $fail->getCreatedAt())) ?></td>
                                 <td><?php p(date('D\, j M Y H:i:s', $fail->getUpdatedAt())) ?></td>

--- a/templates/published.php
+++ b/templates/published.php
@@ -32,7 +32,7 @@ style('files', 'files');
                                 <td><?php p($publication->getId()) ?></td>
                                 <td><?php p($publication->getFilename()) ?></td>
                                 <?php // TODO: echo as user specific timedate ?>
-                                <td><?php p($publication->getStatus()) ?></td>
+                                <td><?php p($_['statuscodes'][$publication->getStatus()]) ?></td>
                                 <td><a target="_blank" href=<?php p($publication->getUrl()) ?>>URL</a></td>
                                 <td><?php p(date('D\, j M Y H:i:s', $publication->getCreatedAt())) ?></td>
                                 <td><?php p(date('D\, j M Y H:i:s', $publication->getUpdatedAt())) ?></td>

--- a/tests/unit/controller/ControllerTest.php
+++ b/tests/unit/controller/ControllerTest.php
@@ -45,7 +45,7 @@ class PageControllerTest extends PHPUnit_Framework_TestCase {
     
     public function testPublished() {
         $result = $this->controller->filterPublished();
-        $this->assertEquals(['user' => 'john', 'publications' => Array ()], $result->getParams());
+        $this->assertEquals(['user' => 'john', 'publications' => Array (), 'statuscodes' => Array ()], $result->getParams());
         $this->assertEquals('published', $result->getTemplateName());
         $this->assertTrue($result instanceof TemplateResponse);
     }
@@ -59,7 +59,7 @@ class PageControllerTest extends PHPUnit_Framework_TestCase {
     
     public function testFailed() {
         $result = $this->controller->filterFailed();
-        $this->assertEquals(['user' => 'john', 'fails' => Array ()], $result->getParams());
+        $this->assertEquals(['user' => 'john', 'fails' => Array (), 'statuscodes' => Array ()], $result->getParams());
         $this->assertEquals('failed', $result->getTemplateName());
         $this->assertTrue($result instanceof TemplateResponse);
     }

--- a/tests/unit/controller/ControllerTest.php
+++ b/tests/unit/controller/ControllerTest.php
@@ -26,16 +26,19 @@ class PageControllerTest extends PHPUnit_Framework_TestCase {
         $mapper = $this->getMockBuilder('OCA\B2shareBridge\Db\FilecacheStatusMapper')
             ->disableOriginalConstructor()
             ->getMock();
-
+        $scMapper = $this->getMockBuilder('OCA\B2shareBridge\Db\StatusCodeMapper')
+            ->disableOriginalConstructor()
+            ->getMock();
+            
 
         $this->controller = new B2shareBridge(
-            'b2sharebridge', $request, $config, $mapper, $this->userId
+            'b2sharebridge', $request, $config, $mapper, $scMapper, $this->userId
         );
     }
 
     public function testIndex() {
         $result = $this->controller->index();
-        $this->assertEquals(['user' => 'john', 'transfers' => Array (), 'publications' => Array (), 'fails' => Array ()], $result->getParams());
+        $this->assertEquals(['user' => 'john', 'transfers' => Array (), 'publications' => Array (), 'fails' => Array (), 'statuscodes' => Array ()], $result->getParams());
         $this->assertEquals('main', $result->getTemplateName());
         $this->assertTrue($result instanceof TemplateResponse);
     }


### PR DESCRIPTION
This pull request creates a new database table for mapping of status code and message, it changes the status in filecache table from string to integer and displays the status message in user view. It will solve the issue #15.

If you have already database entries you need to migrate them. Therefore a sql script is stored at `lib/db/migration.sql`.

Everything is tested with ocdev server and sqlite database.
