### PR TITLE
Better test steps for unit and integration testing

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -95,6 +95,11 @@ jobs:
         if: ${{ matrix.nextcloud-version-branch != 'stable25' }}
         run: ./occ app:check-code b2sharebridge
 
+      - name: Unit Tests
+        run: |
+          cd apps/b2sharebridge
+          phpunit tests
+
       - name: Test Background Job
         if: ${{ matrix.nextcloud-version-branch != 'stable22' }}  # https://github.com/actions/runner/issues/1173   # 'background-job'-cmd is only available since nc23
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -98,7 +98,7 @@ jobs:
       - name: Unit Tests
         run: |
           cd apps/b2sharebridge
-          phpunit tests
+          phpunit --bootstrap tests/bootstrap.php tests
 
       - name: Test Background Job
         if: ${{ matrix.nextcloud-version-branch != 'stable22' }}  # https://github.com/actions/runner/issues/1173   # 'background-job'-cmd is only available since nc23

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -97,8 +97,13 @@ jobs:
 
       - name: Unit Tests
         run: |
-          cd apps/b2sharebridge
-          phpunit --bootstrap tests/bootstrap.php tests
+          cd apps/b2sharebridge/tests
+          phpunit -c phpunit.xml unit
+
+      - name: Integration Tests
+        run: |
+          cd apps/b2sharebridge/tests
+          phpunit -c phpunit.integration.xml integration
 
       - name: Test Background Job
         if: ${{ matrix.nextcloud-version-branch != 'stable22' }}  # https://github.com/actions/runner/issues/1173   # 'background-job'-cmd is only available since nc23
@@ -115,8 +120,3 @@ jobs:
         run: |
           cd apps/b2sharebridge
           phpcs --extensions=php --ignore=*/tests/*,*/templates/*,*/Migration/* .
-          cd tests
-          phpunit -c phpunit.xml
-          phpunit -c phpunit.integration.xml
-      
-

--- a/tests/phpunit.integration.xml
+++ b/tests/phpunit.integration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <phpunit bootstrap="bootstrap.php"
-         strict="true"
+         beStrictAboutOutputDuringTests="true"
          verbose="true"
          timeoutForSmallTests="900"
          timeoutForMediumTests="900"

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <phpunit bootstrap="bootstrap.php"
-         strict="true"
+         beStrictAboutOutputDuringTests="true"
          verbose="true"
          timeoutForSmallTests="900"
          timeoutForMediumTests="900"

--- a/tests/unit/AppInfo/RoutesTest.php
+++ b/tests/unit/AppInfo/RoutesTest.php
@@ -15,7 +15,7 @@ namespace OCA\B2shareBridge\Tests\AppInfo;
 
 use PHPUnit\Framework\TestCase;
 
-class Test extends TestCase
+class RoutesTest extends TestCase
 {
     public function testFile() 
     {


### PR DESCRIPTION
I split up the testing pipeline from one big php job into three, from which only one is allowed to fail.
This shows, that unit and integration tests are running and working!

Depends on #67 